### PR TITLE
Fix idct initialization after uploading data

### DIFF
--- a/graph-creator.js
+++ b/graph-creator.js
@@ -142,7 +142,11 @@ document.onload = (function(d3, saveAs, Blob, undefined){
             var jsonObj = JSON.parse(txtRes);
             thisGraph.deleteGraph(true);
             thisGraph.nodes = jsonObj.nodes;
-            thisGraph.setIdCt(jsonObj.nodes.length + 1);
+            // nodes can be deleted, so we need to look for the largest id
+            const max_id = thisGraph.nodes.reduce(function(prev, curr) {
+              return (prev.id > curr.id) ? prev.id : curr.id
+            });
+            thisGraph.setIdCt(max_id + 1);
             var newEdges = jsonObj.edges;
             newEdges.forEach(function(e, i){
               newEdges[i] = {source: thisGraph.nodes.filter(function(n){return n.id == e.source;})[0],


### PR DESCRIPTION
Since nodes can be deleted, we need to look for the largest id instead of the number of existing nodes. This should fix some of the problems mentioned here: https://github.com/cjrd/directed-graph-creator/issues/8

Maybe a few years late, but I just came across this repo and still found it useful. :)